### PR TITLE
Add exiftool and imagemagick as requirements

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,8 +9,9 @@ To install Twyne, you need the following:
 1. a web server with PHP 7.3 or above;
 2. MariaDB (10.3 or above) or MySQL (5.7 or above)
 3. command-line access to that server;
-4. the `Git`_ version control system; and
-5. the PHP package manager, `Composer`_.
+4. the `Git`_ version control system; 
+5. ``exiftool`` and ``imagemagick`` package; and
+6. the PHP package manager, `Composer`_.
 
 .. _`Git`: https://git-scm.com/
 .. _`Composer`: https://getcomposer.org/


### PR DESCRIPTION
As noted in #123 (closing comment), I had to install `imagemagick` and `exiftool` to make uploading (and resized file) work, so adding them as requirements.