### PR TITLE
Remove and simplify file metadata display

### DIFF
--- a/templates/post/view.html.twig
+++ b/templates/post/view.html.twig
@@ -126,17 +126,12 @@
             <p>
                 <img src="{{ path('file', {id:post.id, size:'D', ext:'jpg'}) }}" alt="Image of the file attached to this post." />
             </p>
-            <ul>
-                <li>
-                    URL:
-                    <a href="{{ url('file', {id:post.id, size:'F', ext:post.file.extension}) }}">
-                        {{ url('file', {id:post.id, size:'F', ext:post.file.extension}) }}
-                    </a>
-                </li>
-                <li>Size: {{ post.file.size|format_memory }}</li>
-                <li>SHA1 checksum: {{ post.file.checksum }}</li>
-                <li>Type: {{ post.file.mimeType }}</li>
-            </ul>
+            <p>
+                <a href="{{ url('file', {id:post.id, size:'F', ext:post.file.extension}) }}" title="{{'posts.save_tooltip'|trans}}" target="_base">
+                    {{'posts.download_link'|trans}}
+                </a>
+                ({{ post.file.size|format_memory }})
+            </p>
         {% endif %}
 
         {% if post.location %}

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -12,6 +12,7 @@ security:
     remember_me: 'Remember me'
 posts:
     replies: 'Replies'
+    download_link: 'Download'
     save_tooltip: 'Save the full version of this file'
     delete:
         gone-will-be-added: 'An HTTP status of "410 Gone" will be added for this post. See %redirects_link% for more information.'


### PR DESCRIPTION
Remove the checksum and type, and unify the download and size into one line.

Bug: GH#133